### PR TITLE
DOCS-2931

### DIFF
--- a/modules/ROOT/pages/asm-secret-group-creation-task.adoc
+++ b/modules/ROOT/pages/asm-secret-group-creation-task.adoc
@@ -200,6 +200,8 @@ Supported ciphers include:
 If you are configuring ciphers to use by an HTTPS API Proxy, you can define additional ciphers used by your proxy instance.
 +
 image::asm-secret-group-creation-task-f012f.png[]
++
+If you add a cipher that's not supported by the Java runtime, you receive a warning, but this does not prevent you from saving the TLS context.
 . Click *Save*.
 
 == Edit a Secret Group


### PR DESCRIPTION
To explain you can still save TLS context in spite of warning