### PR TITLE
Changing two includes to conform to chosen syntax

### DIFF
--- a/modules/ROOT/pages/dos-policy.adoc
+++ b/modules/ROOT/pages/dos-policy.adoc
@@ -18,7 +18,7 @@ Since the source of the request is based on the IP address, if an an attacker sp
 [[anypoint_security_prereqs]]
 == Prerequisites
 
-include::{partialsdir}/anypoint-security-policies-prereqs.adoc[]
+include::partial$anypoint-security-policies-prereqs.adoc[]
 
 
 [[dos_thresholds_and_escalations]]

--- a/modules/ROOT/pages/index-policies.adoc
+++ b/modules/ROOT/pages/index-policies.adoc
@@ -30,7 +30,7 @@ This layer of security provides the same control as any API Manager policy offer
 [[anypoint_security_prereqs]]
 == Prerequisites
 
-include::{partialsdir}/anypoint-security-policies-prereqs.adoc[]
+include::partial$anypoint-security-policies-prereqs.adoc[]
 
 == DoS Policy
 


### PR DESCRIPTION
These links work, but we want all includes to use the same syntax (future-proofing).
Local build w/fullsite.yml displayed the same contents in both files as currently published, no errors.
Local link check  w/fullsite.yml raised no errors (not sure broken includes raise errors with link checker?).
