### PR TITLE
[W-20883703] Update secret group storage limit documentation

### DIFF
--- a/modules/ROOT/pages/_partials/secret-group-limits.adoc
+++ b/modules/ROOT/pages/_partials/secret-group-limits.adoc
@@ -1,12 +1,12 @@
 // Included in asm-secret-group-concept and asm-secret-group-creation
 
 // tag::secret-group-limit-note[]
-NOTE: A maximum of 25 secret groups are allowed per environment per business group. Each secret group can contain a maximum of 350 secrets.
+NOTE: A maximum of 25 secret groups are allowed per environment per business group. Each individual secret group has a maximum storage capacity of 1MB.
 // end::secret-group-limit-note[]
 
 // Included in index-secrets-manager 
 
 // tag::secret-group-limit-list[]
 * A maximum of 25 secret groups per environment per business group are allowed. 
-* Each secret group can contain a maximum of 350 secrets.
+* Each individual secret group has a maximum storage capacity of 1MB.
 // end::secret-group-limit-list[]

--- a/modules/ROOT/pages/index-secrets-manager.adoc
+++ b/modules/ROOT/pages/index-secrets-manager.adoc
@@ -66,7 +66,7 @@ A repository of security certificates from other parties that associate a client
 An entity that creates and maintains a list of CA certificates that are no longer trusted because their associated private keys, or a signing CA, were compromised.
 
 [[limitations]]
-=== Limitations 
+== Limitations 
 
 include::partial$secret-group-limits.adoc[tag=secret-group-limit-list]
 * Shared secrets are used for symmetric encryption and decryption, where the secret is known by both the message sender and the message recipient. These shared secret types are defined, however, Anypoint Platform services can't consume them: 


### PR DESCRIPTION
## Summary
Updated the secret group storage limit documentation to reflect the maximum storage capacity of 1MB per group, replacing the previous limit of 350 secrets per group.

## Changes
- Updated secret group limits in `secret-group-limits.adoc` partial from "350 secrets" to "1MB storage capacity"
- Fixed header level in `index-secrets-manager.adoc` (changed from `===` to `==` for Limitations section)

## Files Changed
- `modules/ROOT/pages/_partials/secret-group-limits.adoc` (Modified)
- `modules/ROOT/pages/index-secrets-manager.adoc` (Modified)

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Update
- [ ] Refactor
- [ ] Documentation

## Testing
- [x] Local build tested
- [x] Links verified
- [ ] Screenshots updated (if applicable)

## Related
- GUS Work Item: W-20883703